### PR TITLE
Don't pin openssl-sys on OpenBSD.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,4 +96,4 @@ doc = false
 
 [patch.crates-io]
 openssl-sys = { git = 'https://github.com/niklasha/rust-openssl.git', branch = 'libressl_3_7' }
-libgit2-sys = { git = "", commit = '68b12efd6463c57deff56f4f7488a042461049d3' }
+libgit2-sys = { git = 'https://github.com/rust-lang/git2-rs.git', commit = '68b12efd6463c57deff56f4f7488a042461049d3' }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,4 +95,4 @@ test = false
 doc = false
 
 [patch.crates-io]
-openssl-sys = { git = 'https://github.com/niklasha/rust-openssl.git', branch = 'libressl37' }
+openssl-sys = { git = 'https://github.com/niklasha/rust-openssl.git', branch = 'libressl_3_7' }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,3 +93,6 @@ name = "cargo-install-update-config"
 path = "src/main-config.rs"
 test = false
 doc = false
+
+[patch.crates-io]
+openssl-sys = { git = 'https://github.com/niklasha/rust-openssl.git', branch = 'libressl37' }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,3 +96,4 @@ doc = false
 
 [patch.crates-io]
 openssl-sys = { git = 'https://github.com/niklasha/rust-openssl.git', branch = 'libressl_3_7' }
+libgit2-sys = { git = "", commit = '68b12efd6463c57deff56f4f7488a042461049d3' }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,9 +69,9 @@ features = ["wrap_help"]
 version = "0.4"
 features = ["http2"]
 
-[target."cfg(all(unix, not(target_os = \"macos\"), not(target_os = \"openbsd\")))".dependencies]  # Matches https://github.com/rust-lang/git2-rs/blob/0.13.25/Cargo.toml
-# https://app.travis-ci.com/github/nabijaczleweli/cargo-update/jobs/548138871#L272 vs https://app.travis-ci.com/github/nabijaczleweli/cargo-update/jobs/550595562#L279
-openssl-sys = "=0.9.70"
+#[target."cfg(all(unix, not(target_os = \"macos\"), not(target_os = \"openbsd\")))".dependencies]  # Matches https://github.com/rust-lang/git2-rs/blob/0.13.25/Cargo.toml
+## https://app.travis-ci.com/github/nabijaczleweli/cargo-update/jobs/548138871#L272 vs https://app.travis-ci.com/github/nabijaczleweli/cargo-update/jobs/550595562#L279
+#openssl-sys = "=0.9.70"
 
 [build-dependencies]
 embed-resource = "1.7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,7 +69,7 @@ features = ["wrap_help"]
 version = "0.4"
 features = ["http2"]
 
-[target."cfg(all(unix, not(target_os = \"macos\")))".dependencies]  # Matches https://github.com/rust-lang/git2-rs/blob/0.13.25/Cargo.toml
+[target."cfg(all(unix, not(target_os = \"macos\")), not(target_os = \"openbsd\"))".dependencies]  # Matches https://github.com/rust-lang/git2-rs/blob/0.13.25/Cargo.toml
 # https://app.travis-ci.com/github/nabijaczleweli/cargo-update/jobs/548138871#L272 vs https://app.travis-ci.com/github/nabijaczleweli/cargo-update/jobs/550595562#L279
 openssl-sys = "=0.9.70"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,7 +69,7 @@ features = ["wrap_help"]
 version = "0.4"
 features = ["http2"]
 
-[target."cfg(all(unix, not(target_os = \"macos\")), not(target_os = \"openbsd\"))".dependencies]  # Matches https://github.com/rust-lang/git2-rs/blob/0.13.25/Cargo.toml
+[target."cfg(all(unix, not(target_os = \"macos\"), not(target_os = \"openbsd\")))".dependencies]  # Matches https://github.com/rust-lang/git2-rs/blob/0.13.25/Cargo.toml
 # https://app.travis-ci.com/github/nabijaczleweli/cargo-update/jobs/548138871#L272 vs https://app.travis-ci.com/github/nabijaczleweli/cargo-update/jobs/550595562#L279
 openssl-sys = "=0.9.70"
 


### PR DESCRIPTION
The ancient openssl-sys version pinned does not recognise modern LibreSSL.